### PR TITLE
Full-page background video

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+        }
         body {
             font-family: 'Noto Sans JP', sans-serif;
         }
@@ -23,12 +27,13 @@
             box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1); /* shadow-lg */
         }
         .video-bg {
-            position: absolute;
+            position: fixed;
             top: 0;
             left: 0;
             width: 100%;
             height: 100%;
             object-fit: cover;
+            pointer-events: none;
             z-index: 0;
         }
         .content-overlay {


### PR DESCRIPTION
## Summary
- set `html, body` height to 100% and removed default margin
- position video backgrounds fixed so they fill the viewport

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686be096634c8324a7471a4d10809822